### PR TITLE
Adding a default for the output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ## Description
 
 This tool pulls findings from AWS Security Hub and outputs them for
-consumption by visualization tools.
+consumption by visualization tools. In order to use this tool, you will
+need to have valid AWS credentials in your environment (or provide a
+profile for the tool to use).
 
 ## Installation
 
@@ -20,19 +22,7 @@ Usage:
   security-hub-collector [OPTIONS]
 
 Application Options:
-  -o, --output=  File to direct output to.
-  -p, --profile= The AWS profile to use. [$AWS_PROFILE]
-  -r, --region=  The AWS region to use. [$AWS_REGION]
-  -m, --teammap= JSON file containing team to account mappings.
-
-Help Options:
-  -h, --help     Show this help message
-
-2021/03/30 14:25:32 could not parse options: Usage:
-  security-hub-collector [OPTIONS]
-
-Application Options:
-  -o, --output=  File to direct output to.
+  -o, --output=  File to direct output to. (default: SecurityHub-Findings.csv)
   -p, --profile= The AWS profile to use. [$AWS_PROFILE]
   -r, --region=  The AWS region to use. [$AWS_REGION]
   -m, --teammap= JSON file containing team to account mappings.
@@ -47,5 +37,5 @@ Help Options:
 Run the command like this:
 
 ```sh
-security-hub-collector -o output.csv -m teammap.json
+security-hub-collector -m teammap.json
 ```

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 // Options describes the command line options available.
 type Options struct {
-	Outfile     string `short:"o" long:"output" required:"true" description:"File to direct output to."`
+	Outfile     string `short:"o" long:"output" required:"false" description:"File to direct output to." default:"SecurityHub-Findings.csv"`
 	Profile     string `short:"p" long:"profile" env:"AWS_PROFILE" required:"false" description:"The AWS profile to use."`
 	Region      string `short:"r" long:"region" env:"AWS_REGION" required:"false" description:"The AWS region to use."`
 	TeamMapFile string `short:"m" long:"teammap" required:"true" description:"JSON file containing team to account mappings."`


### PR DESCRIPTION
Andy's Excel template looks for a file named `SecurityHub-Findings.csv`, so I've made that the default for this tool's output (which can be overridden with the -o flag). I also added a short note to the README about needing AWS credentials to get this to work. I've confirmed that the default for the output works fine.